### PR TITLE
feat: Add research workflow tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "wayback-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/diff": "^5.0.8",
-        "@types/node": "^20.10.0",
+        "@types/diff": "^5.2.3",
+        "@types/node": "^25.2.3",
         "typescript": "^5.3.3"
       },
       "engines": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.8.tgz",
-      "integrity": "sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -39,12 +39,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
-      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -52,14 +52,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -85,13 +86,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.29.tgz",
-      "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/accepts": {
@@ -225,9 +226,9 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -235,11 +236,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -307,9 +308,9 @@
       }
     },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -317,6 +318,10 @@
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -388,9 +393,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -616,10 +621,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -774,9 +782,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -784,9 +792,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -798,14 +806,14 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -851,6 +859,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1118,9 +1135,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1394,18 +1411,18 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/diff": "^5.0.8",
-    "@types/node": "^20.10.0",
+    "@types/diff": "^5.2.3",
+    "@types/node": "^25.2.3",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/src/api/cdx.ts
+++ b/src/api/cdx.ts
@@ -472,6 +472,22 @@ export class CdxApi {
       }
     }
 
+    // Sort results based on sortBy parameter
+    if (params.sortBy) {
+      switch (params.sortBy) {
+        case 'oldest':
+          siteUrls.sort((a, b) => a.firstCapture.localeCompare(b.firstCapture));
+          break;
+        case 'newest':
+          siteUrls.sort((a, b) => b.lastCapture.localeCompare(a.lastCapture));
+          break;
+        case 'captures':
+          siteUrls.sort((a, b) => b.captureCount - a.captureCount);
+          break;
+        // 'urlkey' is default CDX order, no sort needed
+      }
+    }
+
     // Extract subdomains if matchType is domain
     const subdomains = params.matchType === 'domain'
       ? this.extractSubdomains(siteUrls.map(u => u.url), normalizedUrl)

--- a/src/api/research.ts
+++ b/src/api/research.ts
@@ -1,0 +1,292 @@
+import type { WaybackClient } from './client.js';
+import { CdxApi } from './cdx.js';
+import { SnapshotsApi } from './snapshots.js';
+import { WaybackApiError, ERROR_CODES, SnapshotsQuerySchema, SiteUrlsQuerySchema, SnapshotContentQuerySchema } from '../types/index.js';
+
+export interface ExtractLinksParams {
+  url: string;
+  timestamp?: string;
+  includeInternal?: boolean;
+}
+
+export interface ExtractLinksResult {
+  url: string;
+  timestamp: string;
+  totalLinks: number;
+  externalDomains: string[];
+  internalLinks?: string[];
+}
+
+export interface ResearchParams {
+  domain: string;
+  pathPrefix?: string;
+  limit?: number;
+  processLimit?: number;
+}
+
+export interface ProcessedUrl {
+  url: string;
+  timestamp: string;
+  date: string;
+  title: string | null;
+  description: string | null;
+}
+
+export interface Finding {
+  type: 'announcement' | 'jobs' | 'partnership' | 'acquisition' | 'product';
+  url: string;
+  timestamp: string;
+  title: string | null;
+}
+
+export interface ResearchResult {
+  domain: string;
+  totalArchived: number;
+  processed: number;
+  urls: ProcessedUrl[];
+  externalDomains: string[];
+  findings: Finding[];
+  pathPrefix?: string;
+}
+
+// Helper to parse URL - handles both browser and Node environments
+function parseUrl(urlStr: string, base?: string): { hostname: string; href: string } | null {
+  try {
+    // Try using global URL (works in both environments)
+    const url = base ? new (globalThis.URL || URL)(urlStr, base) : new (globalThis.URL || URL)(urlStr);
+    return { hostname: url.hostname, href: url.href };
+  } catch {
+    return null;
+  }
+}
+
+// Helper for delay
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    if (typeof globalThis.setTimeout !== 'undefined') {
+      globalThis.setTimeout(resolve, ms);
+    } else {
+      // Fallback - just resolve immediately
+      resolve();
+    }
+  });
+}
+
+export class ResearchApi {
+  private client: WaybackClient;
+  private cdxApi: CdxApi;
+  private snapshotsApi: SnapshotsApi;
+
+  constructor(client: WaybackClient) {
+    this.client = client;
+    this.cdxApi = new CdxApi(client);
+    this.snapshotsApi = new SnapshotsApi(client);
+  }
+
+  /**
+   * Extract links from an archived page
+   */
+  async extractLinks(params: ExtractLinksParams): Promise<ExtractLinksResult> {
+    // Get the snapshot content
+    let timestamp = params.timestamp;
+    
+    if (!timestamp) {
+      // Get latest snapshot using the schema to apply defaults
+      const snapshotParams = SnapshotsQuerySchema.parse({
+        url: params.url,
+        matchType: 'exact',
+        statusFilter: '200',
+        limit: 1
+      });
+      
+      const snapshots = await this.cdxApi.getSnapshots(snapshotParams);
+      
+      if (snapshots.snapshots.length === 0) {
+        throw new WaybackApiError({
+          code: ERROR_CODES.NOT_FOUND,
+          message: `No archived snapshots found for ${params.url}`
+        });
+      }
+      
+      timestamp = snapshots.snapshots[0].timestamp;
+    }
+
+    // Fetch the content using schema to apply defaults
+    const contentParams = SnapshotContentQuerySchema.parse({
+      url: params.url,
+      timestamp,
+      extractMetadata: false,
+      includeRawHtml: true
+    });
+    
+    const content = await this.snapshotsApi.getSnapshotContent(contentParams);
+
+    const html = content.rawHtml || '';
+    
+    // Extract links
+    const linkRegex = /<a[^>]+href=["']([^"']+)["'][^>]*>/gi;
+    const links = new Set<string>();
+    const externalDomains = new Set<string>();
+    const internalLinks: string[] = [];
+
+    const sourceUrl = parseUrl(params.url);
+    const sourceDomain = sourceUrl ? sourceUrl.hostname.replace(/^www\./, '') : params.url;
+
+    let match;
+    while ((match = linkRegex.exec(html)) !== null) {
+      const href = match[1];
+
+      // Skip anchors, javascript, mailto
+      if (href.startsWith('#') || href.startsWith('javascript:') || href.startsWith('mailto:')) {
+        continue;
+      }
+
+      // Handle relative URLs
+      const absoluteUrl = parseUrl(href, params.url);
+      if (absoluteUrl) {
+        const linkDomain = absoluteUrl.hostname.replace(/^www\./, '');
+
+        links.add(absoluteUrl.href);
+
+        if (linkDomain !== sourceDomain && !linkDomain.includes('archive.org')) {
+          externalDomains.add(linkDomain);
+        } else if (params.includeInternal) {
+          internalLinks.push(absoluteUrl.href);
+        }
+      }
+    }
+
+    return {
+      url: params.url,
+      timestamp,
+      totalLinks: links.size,
+      externalDomains: Array.from(externalDomains).sort(),
+      internalLinks: params.includeInternal ? internalLinks : undefined
+    };
+  }
+
+  /**
+   * Research a domain systematically
+   */
+  async researchDomain(params: ResearchParams): Promise<ResearchResult> {
+    const domain = params.domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+    const limit = params.limit || 100;
+    const processLimit = params.processLimit || 20;
+
+    // Step 1: Get all text URLs, sorted oldest first
+    const urlPattern = params.pathPrefix 
+      ? `${domain}${params.pathPrefix}`
+      : domain;
+
+    // Use schema to apply defaults
+    const siteUrlParams = SiteUrlsQuerySchema.parse({
+      url: urlPattern,
+      matchType: params.pathPrefix ? 'prefix' : 'domain',
+      mimeTypeFilter: 'text/html',
+      statusFilter: '200',
+      sortBy: 'oldest',
+      limit,
+      includeCaptureCounts: false
+    });
+
+    const siteUrls = await this.cdxApi.getSiteUrls(siteUrlParams);
+
+    if (siteUrls.urls.length === 0) {
+      return {
+        domain,
+        totalArchived: 0,
+        processed: 0,
+        urls: [],
+        externalDomains: [],
+        findings: [],
+        pathPrefix: params.pathPrefix
+      };
+    }
+
+    // Step 2: Process URLs and extract info
+    const processedUrls: ProcessedUrl[] = [];
+    const allExternalDomains = new Set<string>();
+    const findings: Finding[] = [];
+
+    const toProcess = Math.min(siteUrls.urls.length, processLimit);
+
+    for (let i = 0; i < toProcess; i++) {
+      const item = siteUrls.urls[i];
+      const url = item.url;
+      const timestamp = item.firstCapture;
+
+      try {
+        // Get content using schema to apply defaults
+        const contentParams = SnapshotContentQuerySchema.parse({
+          url,
+          timestamp,
+          extractMetadata: true,
+          includeRawHtml: true
+        });
+        
+        const content = await this.snapshotsApi.getSnapshotContent(contentParams);
+
+        const html = content.rawHtml || '';
+
+        // Extract links
+        const linkRegex = /<a[^>]+href=["']([^"']+)["'][^>]*>/gi;
+        let match;
+        while ((match = linkRegex.exec(html)) !== null) {
+          const absoluteUrl = parseUrl(match[1], url);
+          if (absoluteUrl) {
+            const sourceUrl = parseUrl(url);
+            const sourceDomain = sourceUrl ? sourceUrl.hostname.replace(/^www\./, '') : '';
+            const linkDomain = absoluteUrl.hostname.replace(/^www\./, '');
+            if (linkDomain !== sourceDomain && !linkDomain.includes('archive.org')) {
+              allExternalDomains.add(linkDomain);
+            }
+          }
+        }
+
+        processedUrls.push({
+          url,
+          timestamp,
+          date: `${timestamp.slice(0, 4)}-${timestamp.slice(4, 6)}-${timestamp.slice(6, 8)}`,
+          title: content.metadata?.title || null,
+          description: content.metadata?.metaDescription || null
+        });
+
+        // Look for interesting findings
+        const lowerHtml = html.toLowerCase();
+        const title = content.metadata?.title || null;
+
+        if (lowerHtml.includes('announcement') || lowerHtml.includes('press release')) {
+          findings.push({ type: 'announcement', url, timestamp, title });
+        }
+        if (lowerHtml.includes('careers') || lowerHtml.includes('job opening') || lowerHtml.includes("we're hiring")) {
+          findings.push({ type: 'jobs', url, timestamp, title });
+        }
+        if (lowerHtml.includes('partnership') || lowerHtml.includes('agreement')) {
+          findings.push({ type: 'partnership', url, timestamp, title });
+        }
+        if (lowerHtml.includes('acquisition') || lowerHtml.includes('acquired')) {
+          findings.push({ type: 'acquisition', url, timestamp, title });
+        }
+        if (lowerHtml.includes('new product') || lowerHtml.includes('launch') || lowerHtml.includes('introducing')) {
+          findings.push({ type: 'product', url, timestamp, title });
+        }
+
+      } catch {
+        // Skip failed URLs
+      }
+
+      // Rate limiting - small delay between requests
+      await delay(100);
+    }
+
+    return {
+      domain,
+      totalArchived: siteUrls.urls.length,
+      processed: processedUrls.length,
+      urls: processedUrls,
+      externalDomains: Array.from(allExternalDomains).sort(),
+      findings,
+      pathPrefix: params.pathPrefix
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import { AvailabilityApi } from '../api/availability.js';
 import { CdxApi } from '../api/cdx.js';
 import { SnapshotsApi } from '../api/snapshots.js';
 import { DiffService } from '../api/diff.js';
+import { ResearchApi } from '../api/research.js';
 import { handleToolError } from '../utils/errors.js';
 import {
   AvailabilityQuerySchema,
@@ -14,6 +15,22 @@ import {
   AnalyzeChangesQuerySchema,
   SiteUrlsQuerySchema
 } from '../types/index.js';
+import { z } from 'zod';
+
+// Schema for extract links
+const ExtractLinksSchema = z.object({
+  url: z.string(),
+  timestamp: z.string().optional(),
+  includeInternal: z.boolean().optional().default(false)
+});
+
+// Schema for research domain
+const ResearchDomainSchema = z.object({
+  domain: z.string(),
+  pathPrefix: z.string().optional(),
+  limit: z.number().min(1).max(1000).optional().default(100),
+  processLimit: z.number().min(1).max(100).optional().default(20)
+});
 
 export interface Tool {
   name: string;
@@ -34,6 +51,7 @@ export function createTools(client: WaybackClient): { tools: Tool[]; handlers: M
   const cdxApi = new CdxApi(client);
   const snapshotsApi = new SnapshotsApi(client);
   const diffService = new DiffService(client);
+  const researchApi = new ResearchApi(client);
 
   const handlers = new Map<string, ToolHandler>();
 
@@ -308,9 +326,66 @@ export function createTools(client: WaybackClient): { tools: Tool[]; handlers: M
           mimeTypeFilter: {
             type: 'string',
             description: 'Filter by MIME type (e.g., "text/html" to exclude images/css/js)'
+          },
+          sortBy: {
+            type: 'string',
+            enum: ['urlkey', 'oldest', 'newest', 'captures'],
+            description: 'Sort order: urlkey (default, alphabetical), oldest (first archived), newest (most recently archived), captures (most captured)'
           }
         },
         required: ['url']
+      }
+    },
+
+    // 9. Extract Links
+    {
+      name: 'wayback_extract_links',
+      description: 'Extract all outbound links from an archived page. Returns external domains found, useful for discovering related sites to research.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description: 'The URL to extract links from'
+          },
+          timestamp: {
+            type: 'string',
+            description: 'Snapshot timestamp (YYYYMMDDhhmmss). If not provided, uses latest snapshot.'
+          },
+          includeInternal: {
+            type: 'boolean',
+            description: 'Include internal links (same domain) - default: false'
+          }
+        },
+        required: ['url']
+      }
+    },
+
+    // 10. Research Domain
+    {
+      name: 'wayback_research_domain',
+      description: 'Systematic domain research workflow: fetches archived URLs (oldest first, text/html only), extracts content and metadata, finds external domains to research next, and flags interesting findings (announcements, job posts, partnerships).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          domain: {
+            type: 'string',
+            description: 'Domain to research (e.g., "zenimax.com")'
+          },
+          pathPrefix: {
+            type: 'string',
+            description: 'Filter by URL path prefix (e.g., "/news/" for large sites)'
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum URLs to fetch (default: 100)'
+          },
+          processLimit: {
+            type: 'number',
+            description: 'Maximum URLs to process for content extraction (default: 20)'
+          }
+        },
+        required: ['domain']
       }
     }
   ];
@@ -454,6 +529,28 @@ export function createTools(client: WaybackClient): { tools: Tool[]; handlers: M
     try {
       const params = SiteUrlsQuerySchema.parse(args);
       const result = await cdxApi.getSiteUrls(params);
+      return JSON.stringify(result, null, 2);
+    } catch (error) {
+      return handleToolError(error);
+    }
+  });
+
+  // 9. Extract Links
+  handlers.set('wayback_extract_links', async (args) => {
+    try {
+      const params = ExtractLinksSchema.parse(args);
+      const result = await researchApi.extractLinks(params);
+      return JSON.stringify(result, null, 2);
+    } catch (error) {
+      return handleToolError(error);
+    }
+  });
+
+  // 10. Research Domain
+  handlers.set('wayback_research_domain', async (args) => {
+    try {
+      const params = ResearchDomainSchema.parse(args);
+      const result = await researchApi.researchDomain(params);
       return JSON.stringify(result, null, 2);
     } catch (error) {
       return handleToolError(error);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -367,7 +367,8 @@ export const SiteUrlsQuerySchema = z.object({
   limit: z.number().min(1).max(10000).optional().default(1000),
   includeSubdomains: z.boolean().optional().default(true),
   includeCaptureCounts: z.boolean().optional().default(false),
-  mimeTypeFilter: z.string().optional()
+  mimeTypeFilter: z.string().optional(),
+  sortBy: z.enum(["urlkey", "oldest", "newest", "captures"]).optional().default("urlkey")
 });
 
 export type SiteUrlsQuery = z.infer<typeof SiteUrlsQuerySchema>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Adds systematic domain research workflow based on @bogorad222's Wayback Machine research methodology.

## New Tools

### wayback_get_site_urls (enhanced)
- Added `sortBy` parameter: `oldest`, `newest`, `captures`, `urlkey`

### wayback_extract_links (new)
- Extracts outbound links from archived page
- Returns external domains found (for researching next)

### wayback_research_domain (new)  
- Full research workflow:
  1. Fetches archived URLs (oldest first, text/html only)
  2. Processes content for metadata
  3. Extracts external domains to research next
  4. Flags interesting findings (announcements, jobs, partnerships)

## Example Usage

```
wayback_research_domain({
  domain: "zenimax.com",
  limit: 100,
  processLimit: 20
})
```

Returns processed URLs with metadata, external domains found, and flagged findings.

## Technical Changes

- Added `src/api/research.ts` with ResearchApi class
- Updated `src/api/cdx.ts` to handle sortBy parameter  
- Updated `src/tools/index.ts` with new tool definitions
- Fixed TypeScript config (added @types/node)